### PR TITLE
#168842328 Having consistent and simple colors in sign-up and sign-in page

### DIFF
--- a/UI/css/login.css
+++ b/UI/css/login.css
@@ -4,9 +4,7 @@ a.forget-password {
     color: #453376;
 }
 form {
-    background-image: url("../assets/images/login_form_bg.jpg");
-    background-attachment: fixed;
-    background-size: cover;
+    background-color: #ebedee;
     box-shadow: 0px 5px 20px #ebedee;
     margin-top: 8rem !important;
     margin-bottom: 8rem !important;

--- a/UI/css/signup.css
+++ b/UI/css/signup.css
@@ -2,12 +2,9 @@ form .field {
     margin-bottom: 1em;
 }
 form {
-    background-image: url("../assets/images/signup_form_bg.jpg");
-    background-attachment: fixed;
-    background-size: cover;
+    background-color: #ebedee;
     box-shadow: 0px 5px 20px #ebedee;
     margin-top: 3rem !important;
-
     margin-bottom: 3rem !important;
 }
 form .field input, form .field select {


### PR DESCRIPTION
#### What does this PR do?
Solving issue #34 about the inconsistency of colors on sign-up and sign-in page
#### Description of Task to be completed?
 - Change background color for signup page
 - Change background color for signup page
#### How should this be manually tested?
After cloning the repo cd into UI folder then open `signin.html` and `signup.html` from the pages directory
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
#168842328
#### Screenshots (if appropriate)
SignIn
![Screenshot_20190930_175259_andela_feedback_login](https://user-images.githubusercontent.com/8038879/65896253-2ddfcd80-e3ad-11e9-83d8-4d95ed8f1c25.png)
SignUp
![Screenshot_20190930_175346_andela_feedback_signup](https://user-images.githubusercontent.com/8038879/65896303-3f28da00-e3ad-11e9-9ff8-bbdfd856b3f1.png)
#### Questions:
N/A

[ Finishes #168842328 ]